### PR TITLE
Fix README storage reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `TonConnect` class is responsible for managing connections to TON wallets. I
 
 ### Initializing TonConnect
 
-To initialize the `TonConnect` class, you need to provide the manifest URL and a storage instance. The manifest URL is the URL to the manifest file of your app, and the storage instance is used to store connection data. Note that the first argument to `DictStorage` is the user id.
+To initialize the `TonConnect` class, you need to provide the manifest URL and a storage instance. The manifest URL is the URL to the manifest file of your app, and the storage instance is used to store connection data. Note that the first argument to `DictBridgeStorage` is the user id.
 
 ```python
 from ton_connect.connector import TonConnect


### PR DESCRIPTION
## Summary
- fix README to reference `DictBridgeStorage`

## Testing
- `poetry run ruff check ton_connect`
- `poetry run mypy ton_connect` *(fails: incompatible types)*

------
https://chatgpt.com/codex/tasks/task_e_684328af04108331b7931d3971f76452